### PR TITLE
Add PWM bridge to translate CAN traffic into PWM CSV output

### DIFF
--- a/docs/pwm_bridge.md
+++ b/docs/pwm_bridge.md
@@ -1,87 +1,164 @@
-# PWM Bridge
+# PWM bridge – plain-language guide
 
-This document describes how to mirror openpilot's CAN traffic as PWM samples so
-that development boards or other embedded controllers can interface with the
-system without implementing a CAN stack.
+This page walks through the CAN-to-PWM helper that was added to openpilot.  It
+is written in very simple English so you can copy, paste, and run the exact
+commands without digging into the source code first.
 
-## Overview
+The bridge lets openpilot **pretend it is driving a real car**, but instead of
+talking to a CAN bus it writes the “car commands” out as PWM values inside a CSV
+file.  That CSV can then be read by a microcontroller on a scooter (or any
+project that understands PWM signals).
 
-The bridge is implemented in `selfdrive/pwm_bridge`.  It subscribes to the
-standard `can` messaging channel and converts every byte of each CAN frame into
-a PWM value.  The conversion is deterministic: bytes in the CAN payload are
-linearly mapped to a configurable pulse width (defaulting to 1000–2000 μs at
-50 Hz).  The generated PWM samples are written to a CSV file that can be tailed
-or streamed to downstream tooling.
+---
 
-```
-CAN frame 0x123 -> [0x10, 0x80, 0xFF]
-            │
-            ├──> PWM channel 0: 1062 μs (10 % duty @ 50 Hz)
-            ├──> PWM channel 1: 1500 μs (50 % duty @ 50 Hz)
-            └──> PWM channel 2: 2000 μs (100 % duty @ 50 Hz)
-```
+## 1. One-line setup and launch
 
-## Setup
-
-Openpilot already ships with a helper that bootstraps the Python environment.
-The following one-line command creates the environment and installs openpilot in
-editable mode, making the PWM bridge available immediately:
+Copy and paste the line below into a shell inside the openpilot repository.
+This installs everything and then starts the webcam-based simulator plus the PWM
+bridge.  When the command finishes, the CSV file will start filling with PWM
+numbers.
 
 ```bash
-./scripts/setup_pwm_bridge.sh
+./scripts/setup_pwm_bridge.sh && ./scripts/run_webcam_pwm_autopilot.sh
 ```
 
-This script creates a dedicated virtual environment in `./pwm-env` and installs
-openpilot along with the minimal extra dependencies required to access a USB or
-laptop webcam via OpenCV.
+What happens automatically:
 
-## Running the Webcam-Enabled Autopilot Stack
+1. A Python virtual environment called `pwm-env` is created (or reused).
+2. openpilot and the CAN→PWM tools are installed into that environment.
+3. openpilot boots in webcam mode, so it thinks the webcam feed is the forward
+   camera of a car.
+4. The bridge listens to the fake CAN bus traffic that openpilot sends to the
+   simulated car.
+5. Every CAN byte becomes a PWM value, and each value is written into
+   `~/openpilot_pwm/pwm_capture.csv`.
 
-Once the environment is ready, the entire stack (openpilot, webcam ingestion,
-and the PWM bridge) can be launched with a single command:
+If you ever need to stop the system, press <kbd>Ctrl</kbd>+<kbd>C</kbd>.  All
+processes exit cleanly.
+
+---
+
+## 2. What each helper file does
+
+| File | Why it matters |
+|------|----------------|
+| `scripts/setup_pwm_bridge.sh` | Creates the Python environment, installs dependencies (openpilot, OpenCV) and leaves you ready to launch. |
+| `scripts/run_webcam_pwm_autopilot.sh` | Activates the environment, launches openpilot with the webcam simulator, starts the PWM bridge, and saves the CSV output. |
+| `selfdrive/pwm_bridge/bridge.py` | Connects to openpilot’s CAN messages, converts each one to PWM samples, and writes CSV rows. |
+| `selfdrive/pwm_bridge/translator.py` | Holds the math that maps raw CAN bytes (0–255) into PWM duty cycles and pulse widths. |
+| `docs/pwm_bridge.md` (this file) | Explains how to run everything and how to interpret the CSV output. |
+
+---
+
+## 3. Understanding the PWM CSV
+
+The CSV is created at `~/openpilot_pwm/pwm_capture.csv` (change the
+`PWM_OUTPUT_DIR` environment variable if you need another location).  Each line
+shows one PWM channel derived from one CAN frame.
+
+| Column | In plain words |
+|--------|----------------|
+| `logMonoTime` | When the CAN message was created (nanoseconds since boot). |
+| `address` | Which CAN address the message came from.  Think of this as the “message ID”. |
+| `src` | Which CAN bus the message came from (0 is usually camera, 1 is powertrain, etc.). |
+| `busTime` | Timing info from the CAN hardware.  Most people can ignore this. |
+| `channel` | PWM channel number.  Channel 0 is the first data byte, channel 1 is the second, and so on. |
+| `dutyCycle` | Duty cycle value between 0.0 and 1.0.  Higher means “more on”. |
+| `pulseWidthUs` | Pulse width in microseconds.  Useful if your MCU expects 1000–2000 μs steering/throttle style PWM. |
+
+### Mapping cheat sheet
+
+Every byte from the CAN frame becomes one PWM channel:
+
+```
+CAN frame 0x123 (data = [0x10, 0x80, 0xFF])
+  ├─ Channel 0 gets 0x10 → 1062 µs pulse (~10 % duty at 50 Hz)
+  ├─ Channel 1 gets 0x80 → 1500 µs pulse (~50 % duty at 50 Hz)
+  └─ Channel 2 gets 0xFF → 2000 µs pulse (~100 % duty at 50 Hz)
+```
+
+This mapping is fixed and repeatable:
+
+* Raw CAN byte 0 = minimum pulse (1000 µs by default)
+* Raw CAN byte 128 = middle pulse (1500 µs by default)
+* Raw CAN byte 255 = maximum pulse (2000 µs by default)
+
+You can change the range or the frequency when you launch the bridge:
 
 ```bash
-./scripts/run_webcam_pwm_autopilot.sh
+python -m openpilot.selfdrive.pwm_bridge.bridge ~/openpilot_pwm/custom.csv \
+  --frequency 100 --min-us 900 --max-us 2100
 ```
 
-The script performs the following steps:
+> **Tip:** 50 Hz with 1000–2000 µs is the normal hobby servo range.  Increase
+> the frequency or adjust the limits if your scooter MCU needs something else.
 
-1. Activates the virtual environment created during setup.
-2. Starts openpilot in **webcam** mode with the simulator loopback enabled so it
-   behaves as if it were connected to a real vehicle.
-3. Launches `selfdrive.pwm_bridge.bridge`, writing PWM samples to
-   `~/openpilot_pwm/pwm_capture.csv` by default.
+---
 
-The bridge prints progress updates every 500 PWM samples.  You can halt the
-stack at any time with <kbd>Ctrl</kbd> + <kbd>C</kbd>; both the openpilot
-processes and the PWM bridge shut down gracefully.
+## 4. Checking that everything is running
 
-## Consuming the CSV Output
+1. **Look at the logs:** The launch script prints messages like `wrote 500 pwm
+   samples in 8.2s`.  That means data is flowing.
+2. **Watch the CSV live:**
 
-Each row in the CSV file contains:
+   ```bash
+   tail -f ~/openpilot_pwm/pwm_capture.csv
+   ```
 
-| Column        | Description                                                |
-|---------------|------------------------------------------------------------|
-| `logMonoTime` | nanosecond timestamp from the openpilot messaging system.  |
-| `address`     | CAN frame address (identifier).                            |
-| `src`         | Source bus index.                                          |
-| `busTime`     | Raw bus timing from the CAN message.                       |
-| `channel`     | PWM channel number derived from the payload index.         |
-| `dutyCycle`   | Duty cycle expressed as a fraction (0–1).                  |
-| `pulseWidthUs`| Pulse width for the current channel in microseconds.       |
+   You should see new rows appear every few seconds.
+3. **Openpilot UI:** When the simulator is running you can also open the Qt UI
+   (`./launch_openpilot.sh`) to confirm it sees the webcam video and is
+   “engaged”.
 
-The CSV can be analysed in real time (for example via `tail -f`) or fed into a
-microcontroller over serial/USB for hardware-in-the-loop experiments.
+Because this is a webcam-based simulator, openpilot believes it is in a car and
+keeps publishing steering/throttle/brake CAN messages.  The bridge captures all
+of those without talking to a real vehicle.
 
-## Customisation
+---
 
-`selfdrive.pwm_bridge.bridge` exposes several CLI flags for tuning:
+## 5. Using the PWM values on your scooter
 
-* `--frequency` — PWM output frequency (Hz), default `50`.
-* `--min-us` / `--max-us` — Minimum/maximum pulse widths (μs), default
-  `1000` and `2000`.
-* `--no-console` — Suppress progress messages on `stderr`.
+* Point your microcontroller (for example, an STM32 or ESP32) at the CSV file
+  or stream it over serial/USB.
+* For each line, match `channel` to the PWM output you care about (steering,
+  throttle, brake, etc.).  You may need to log the scooter’s original CAN data
+  to figure out which CAN addresses hold the signals you want.
+* Use the provided `pulseWidthUs` column directly if your firmware expects the
+  typical RC-style servo format.
+* If you want to drive real hardware, replace the CSV writer with code that sets
+  hardware PWM timers using the same duty cycle/pulse width numbers.
 
-Refer to the module docstring or run `python -m selfdrive.pwm_bridge.bridge -h`
-for the full list of options.
+> **Important safety reminder:** The webcam simulator is perfect for software
+> bring-up, but a real scooter will need proper calibration and safety checks.
+> Double-check every signal path before feeding the PWM outputs into the MCU
+> that controls a live vehicle.
+
+---
+
+## 6. Troubleshooting quick answers
+
+| Problem | Quick fix |
+|---------|-----------|
+| `Virtual environment not found` | Run `./scripts/setup_pwm_bridge.sh` before the launch script. |
+| CSV file is empty | Give the simulator a few seconds; the first CAN messages take a moment to appear.  Also check that the webcam is detected. |
+| Need a different output folder | Set `PWM_OUTPUT_DIR=/path/to/folder` before running the launch script. |
+| Want to run bridge alone | `source pwm-env/bin/activate` and then run `python -m openpilot.selfdrive.pwm_bridge.bridge ~/file.csv`. |
+
+If you hit something else, the bridge logs errors to the console before it
+exits, so start by reading the terminal output.
+
+---
+
+## 7. Summary for quick copy/paste
+
+```
+# inside the openpilot repo
+./scripts/setup_pwm_bridge.sh && ./scripts/run_webcam_pwm_autopilot.sh
+
+# watch the PWM stream
+tail -f ~/openpilot_pwm/pwm_capture.csv
+```
+
+That is all you need to boot the simulator, make openpilot think it is driving,
+and see the PWM values it would send to a real scooter.
 

--- a/docs/pwm_bridge.md
+++ b/docs/pwm_bridge.md
@@ -1,0 +1,87 @@
+# PWM Bridge
+
+This document describes how to mirror openpilot's CAN traffic as PWM samples so
+that development boards or other embedded controllers can interface with the
+system without implementing a CAN stack.
+
+## Overview
+
+The bridge is implemented in `selfdrive/pwm_bridge`.  It subscribes to the
+standard `can` messaging channel and converts every byte of each CAN frame into
+a PWM value.  The conversion is deterministic: bytes in the CAN payload are
+linearly mapped to a configurable pulse width (defaulting to 1000–2000 μs at
+50 Hz).  The generated PWM samples are written to a CSV file that can be tailed
+or streamed to downstream tooling.
+
+```
+CAN frame 0x123 -> [0x10, 0x80, 0xFF]
+            │
+            ├──> PWM channel 0: 1062 μs (10 % duty @ 50 Hz)
+            ├──> PWM channel 1: 1500 μs (50 % duty @ 50 Hz)
+            └──> PWM channel 2: 2000 μs (100 % duty @ 50 Hz)
+```
+
+## Setup
+
+Openpilot already ships with a helper that bootstraps the Python environment.
+The following one-line command creates the environment and installs openpilot in
+editable mode, making the PWM bridge available immediately:
+
+```bash
+./scripts/setup_pwm_bridge.sh
+```
+
+This script creates a dedicated virtual environment in `./pwm-env` and installs
+openpilot along with the minimal extra dependencies required to access a USB or
+laptop webcam via OpenCV.
+
+## Running the Webcam-Enabled Autopilot Stack
+
+Once the environment is ready, the entire stack (openpilot, webcam ingestion,
+and the PWM bridge) can be launched with a single command:
+
+```bash
+./scripts/run_webcam_pwm_autopilot.sh
+```
+
+The script performs the following steps:
+
+1. Activates the virtual environment created during setup.
+2. Starts openpilot in **webcam** mode with the simulator loopback enabled so it
+   behaves as if it were connected to a real vehicle.
+3. Launches `selfdrive.pwm_bridge.bridge`, writing PWM samples to
+   `~/openpilot_pwm/pwm_capture.csv` by default.
+
+The bridge prints progress updates every 500 PWM samples.  You can halt the
+stack at any time with <kbd>Ctrl</kbd> + <kbd>C</kbd>; both the openpilot
+processes and the PWM bridge shut down gracefully.
+
+## Consuming the CSV Output
+
+Each row in the CSV file contains:
+
+| Column        | Description                                                |
+|---------------|------------------------------------------------------------|
+| `logMonoTime` | nanosecond timestamp from the openpilot messaging system.  |
+| `address`     | CAN frame address (identifier).                            |
+| `src`         | Source bus index.                                          |
+| `busTime`     | Raw bus timing from the CAN message.                       |
+| `channel`     | PWM channel number derived from the payload index.         |
+| `dutyCycle`   | Duty cycle expressed as a fraction (0–1).                  |
+| `pulseWidthUs`| Pulse width for the current channel in microseconds.       |
+
+The CSV can be analysed in real time (for example via `tail -f`) or fed into a
+microcontroller over serial/USB for hardware-in-the-loop experiments.
+
+## Customisation
+
+`selfdrive.pwm_bridge.bridge` exposes several CLI flags for tuning:
+
+* `--frequency` — PWM output frequency (Hz), default `50`.
+* `--min-us` / `--max-us` — Minimum/maximum pulse widths (μs), default
+  `1000` and `2000`.
+* `--no-console` — Suppress progress messages on `stderr`.
+
+Refer to the module docstring or run `python -m selfdrive.pwm_bridge.bridge -h`
+for the full list of options.
+

--- a/scripts/run_webcam_pwm_autopilot.sh
+++ b/scripts/run_webcam_pwm_autopilot.sh
@@ -9,12 +9,14 @@ if [[ ! -d "${ENV_DIR}" ]]; then
   exit 1
 fi
 
+echo "[pwm-bridge] Activating virtual environment at ${ENV_DIR}" >&2
 source "${ENV_DIR}/bin/activate"
 
 OUTPUT_DIR="${PWM_OUTPUT_DIR:-${HOME}/openpilot_pwm}"
 OUTPUT_FILE="${OUTPUT_DIR}/pwm_capture.csv"
 
 mkdir -p "${OUTPUT_DIR}"
+echo "[pwm-bridge] Writing PWM CSV to ${OUTPUT_FILE}" >&2
 
 cleanup() {
   for pid in ${PIDS[@]:-}; do
@@ -24,15 +26,18 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
+echo "[pwm-bridge] Starting openpilot in webcam simulator mode" >&2
 USE_WEBCAM=1 ./tools/sim/launch_openpilot.sh &
 PIDS=($!)
 
 sleep 10
 
+echo "[pwm-bridge] Spinning up simulator bridge" >&2
 USE_WEBCAM=1 SIMULATOR=1 python -m openpilot.tools.sim.run_bridge &
 PIDS+=($!)
 
 sleep 5
 
+echo "[pwm-bridge] Mirroring CAN traffic to PWM CSV" >&2
 python -m openpilot.selfdrive.pwm_bridge.bridge "${OUTPUT_FILE}"
 

--- a/scripts/run_webcam_pwm_autopilot.sh
+++ b/scripts/run_webcam_pwm_autopilot.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+ENV_DIR="${PROJECT_ROOT}/pwm-env"
+
+if [[ ! -d "${ENV_DIR}" ]]; then
+  echo "Virtual environment not found. Run ./scripts/setup_pwm_bridge.sh first." >&2
+  exit 1
+fi
+
+source "${ENV_DIR}/bin/activate"
+
+OUTPUT_DIR="${PWM_OUTPUT_DIR:-${HOME}/openpilot_pwm}"
+OUTPUT_FILE="${OUTPUT_DIR}/pwm_capture.csv"
+
+mkdir -p "${OUTPUT_DIR}"
+
+cleanup() {
+  for pid in ${PIDS[@]:-}; do
+    kill "${pid}" >/dev/null 2>&1 || true
+  done
+}
+
+trap cleanup EXIT INT TERM
+
+USE_WEBCAM=1 ./tools/sim/launch_openpilot.sh &
+PIDS=($!)
+
+sleep 10
+
+USE_WEBCAM=1 SIMULATOR=1 python -m openpilot.tools.sim.run_bridge &
+PIDS+=($!)
+
+sleep 5
+
+python -m openpilot.selfdrive.pwm_bridge.bridge "${OUTPUT_FILE}"
+

--- a/scripts/setup_pwm_bridge.sh
+++ b/scripts/setup_pwm_bridge.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+ENV_DIR="${PROJECT_ROOT}/pwm-env"
+
+if [[ ! -d "${ENV_DIR}" ]]; then
+  echo "[pwm-bridge] Creating virtual environment at ${ENV_DIR}" >&2
+  python3 -m venv "${ENV_DIR}"
+fi
+
+source "${ENV_DIR}/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install -e "${PROJECT_ROOT}"
+python -m pip install opencv-python
+
+echo "[pwm-bridge] Environment ready. Activate it with:"
+echo "  source ${ENV_DIR}/bin/activate"
+

--- a/selfdrive/pwm_bridge/__init__.py
+++ b/selfdrive/pwm_bridge/__init__.py
@@ -1,0 +1,9 @@
+"""Utilities for translating openpilot CAN traffic to PWM samples.
+
+This package exposes helper classes that make it easy to mirror CAN bus
+messages on a set of virtual PWM channels.  The modules are intentionally
+lightweight so they can be imported by external tooling or executed as a
+standalone script.  See :mod:`selfdrive.pwm_bridge.bridge` for the command
+line entry point.
+"""
+

--- a/selfdrive/pwm_bridge/bridge.py
+++ b/selfdrive/pwm_bridge/bridge.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Stream CAN traffic from openpilot and mirror it as PWM samples.
+
+The script subscribes to the ``can`` messaging channel, converts the payload of
+each CAN frame into PWM information, and writes the result to a CSV file.  This
+allows hobby hardware to consume the generated PWM signals without needing to
+parse CAN frames directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+from cereal import messaging
+
+from openpilot.selfdrive.pwm_bridge.translator import CanToPwmTranslator, PwmSample
+
+
+def _write_header(writer: csv.writer) -> None:
+  writer.writerow([
+    "logMonoTime",
+    "address",
+    "src",
+    "busTime",
+    "channel",
+    "dutyCycle",
+    "pulseWidthUs",
+  ])
+
+
+def _samples_from_message(translator: CanToPwmTranslator, msg) -> Iterable[PwmSample]:
+  assert msg.which() == 'can'
+  log_mono_time = msg.logMonoTime
+
+  for frame in msg.can:
+    yield from translator.translate(
+      log_mono_time=log_mono_time,
+      address=frame.address,
+      src=frame.src,
+      bus_time=frame.busTime,
+      data=frame.dat,
+    )
+
+
+def stream_pwm(output_path: Path, *, frequency_hz: float, min_us: float,
+               max_us: float, no_console: bool) -> None:
+  translator = CanToPwmTranslator(
+    frequency_hz=frequency_hz,
+    min_pulse_us=min_us,
+    max_pulse_us=max_us,
+  )
+
+  sock = messaging.sub_sock('can', conflate=False)
+  poller = messaging.Poller()
+  poller.register(sock)
+
+  output_path.parent.mkdir(parents=True, exist_ok=True)
+  with output_path.open('w', newline='') as output_file:
+    writer = csv.writer(output_file)
+    _write_header(writer)
+
+    start_time = time.monotonic()
+    received = 0
+
+    while True:
+      polled = poller.poll(1000)
+      if not polled:
+        continue
+
+      message = messaging.recv_one(sock)
+      if message is None:
+        continue
+
+      for sample in _samples_from_message(translator, message):
+        writer.writerow([
+          sample.log_mono_time,
+          sample.address,
+          sample.src,
+          sample.bus_time,
+          sample.channel,
+          f"{sample.duty_cycle:.6f}",
+          f"{sample.pulse_width_us:.3f}",
+        ])
+        received += 1
+
+      if not no_console and received and received % 500 == 0:
+        elapsed = time.monotonic() - start_time
+        print(f"wrote {received} pwm samples in {elapsed:.1f}s", file=sys.stderr)
+
+
+def _parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description="Mirror CAN messages as PWM CSV output")
+  parser.add_argument("output", type=Path, help="Destination CSV file")
+  parser.add_argument("--frequency", type=float, default=50.0,
+                      help="PWM frequency in hertz (default: 50Hz)")
+  parser.add_argument("--min-us", type=float, default=1000.0,
+                      help="Minimum pulse width in microseconds (default: 1000)")
+  parser.add_argument("--max-us", type=float, default=2000.0,
+                      help="Maximum pulse width in microseconds (default: 2000)")
+  parser.add_argument("--no-console", action='store_true',
+                      help="Disable progress logging on stderr")
+  return parser.parse_args()
+
+
+def main() -> None:
+  args = _parse_args()
+
+  def _handle_sigint(signum, frame):
+    raise KeyboardInterrupt()
+
+  signal.signal(signal.SIGINT, _handle_sigint)
+  signal.signal(signal.SIGTERM, _handle_sigint)
+
+  try:
+    stream_pwm(args.output, frequency_hz=args.frequency, min_us=args.min_us,
+               max_us=args.max_us, no_console=args.no_console)
+  except KeyboardInterrupt:
+    print("PWM bridge stopped", file=sys.stderr)
+
+
+if __name__ == "__main__":
+  main()
+

--- a/selfdrive/pwm_bridge/translator.py
+++ b/selfdrive/pwm_bridge/translator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass
+class PwmSample:
+  """A single PWM sample derived from a CAN frame."""
+
+  log_mono_time: int
+  address: int
+  src: int
+  bus_time: int
+  channel: int
+  duty_cycle: float
+  pulse_width_us: float
+
+
+class CanToPwmTranslator:
+  """Convert CAN frames into PWM duty cycles.
+
+  The mapping implemented here is intentionally generic: each byte in a CAN
+  data payload is interpreted as a PWM channel value with a configurable
+  minimum and maximum pulse width.  This keeps the code flexible enough for
+  prototyping while still providing deterministic behaviour that can be tested
+  without access to vehicle specific calibration data.
+  """
+
+  def __init__(self, *, min_pulse_us: float = 1000.0, max_pulse_us: float = 2000.0,
+               frequency_hz: float = 50.0) -> None:
+    if min_pulse_us <= 0 or max_pulse_us <= 0:
+      raise ValueError("Pulse widths must be positive")
+    if max_pulse_us <= min_pulse_us:
+      raise ValueError("max_pulse_us must be greater than min_pulse_us")
+    if frequency_hz <= 0:
+      raise ValueError("PWM frequency must be positive")
+
+    self._min_pulse_us = float(min_pulse_us)
+    self._max_pulse_us = float(max_pulse_us)
+    self._frequency_hz = float(frequency_hz)
+
+  @property
+  def min_pulse_us(self) -> float:
+    return self._min_pulse_us
+
+  @property
+  def max_pulse_us(self) -> float:
+    return self._max_pulse_us
+
+  @property
+  def frequency_hz(self) -> float:
+    return self._frequency_hz
+
+  def translate(self, *, log_mono_time: int, address: int, src: int, bus_time: int,
+                data: Iterable[int]) -> List[PwmSample]:
+    """Translate a CAN frame into a list of :class:`PwmSample` values."""
+
+    samples: List[PwmSample] = []
+    for channel, raw_value in enumerate(data):
+      pulse_width = self._pulse_width_from_raw(raw_value)
+      duty_cycle = self._pulse_to_duty_cycle(pulse_width)
+
+      samples.append(PwmSample(
+        log_mono_time=log_mono_time,
+        address=address,
+        src=src,
+        bus_time=bus_time,
+        channel=channel,
+        duty_cycle=duty_cycle,
+        pulse_width_us=pulse_width,
+      ))
+
+    return samples
+
+  def _pulse_width_from_raw(self, value: int) -> float:
+    value = max(0, min(255, int(value)))
+    normalized = value / 255.0
+    return self._min_pulse_us + normalized * (self._max_pulse_us - self._min_pulse_us)
+
+  def _pulse_to_duty_cycle(self, pulse_width: float) -> float:
+    period_us = 1_000_000.0 / self._frequency_hz
+    pulse_width = max(self._min_pulse_us, min(self._max_pulse_us, pulse_width))
+    return pulse_width / period_us
+


### PR DESCRIPTION
## Summary
- add a PWM bridge package that converts openpilot CAN messages into PWM samples and writes CSV output
- include setup and launch scripts to start openpilot in webcam simulator mode alongside the bridge
- document the workflow and CSV format for downstream consumers

## Testing
- python -m compileall selfdrive/pwm_bridge

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691644250cb48323986c0ffd47f6b852)