### PR TITLE
Add raw actuator output mode (skip CAN sends)

### DIFF
--- a/docs/how-to/raw-actuator-output.md
+++ b/docs/how-to/raw-actuator-output.md
@@ -1,0 +1,41 @@
+# Raw actuator output (no CAN send)
+
+This guide explains how to run openpilot while *only* publishing raw actuator values,
+without transmitting CAN messages to the vehicle. This is useful for offline analysis,
+simulation, or validating controller outputs without touching the bus.
+
+## What changes when raw actuator output is enabled
+
+When raw actuator output is enabled:
+
+- `carOutput.actuatorsOutput` continues to publish raw actuator values (steering, accel, braking, etc.).
+- No messages are published on the `sendcan` socket.
+- Control logic and state estimation still run normally.
+
+## Enable raw actuator output
+
+You can enable raw actuator output in one of two ways:
+
+1. **Environment variable**
+
+   ```
+   export RAW_ACTUATORS_ONLY=1
+   ```
+
+2. **Persistent param**
+
+   ```
+   ./scripts/param set RawActuatorsOnly 1
+   ```
+
+Either method disables CAN sends and leaves `carOutput` as the primary output.
+
+## Observing actuator outputs
+
+Subscribe to `carOutput` to read raw actuator values:
+
+```
+./tools/cabana/cabana.sh  # or any cereal subscriber
+```
+
+Look for `carOutput.actuatorsOutput.*` fields in the message stream.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - How-to:
     - Turn the speed blue: how-to/turn-the-speed-blue.md
     - Connect to a comma 3X: how-to/connect-to-comma.md
+    - Raw actuator output (no CAN send): how-to/raw-actuator-output.md
     # - Make your first pull request: how-to/make-first-pr.md
     #- Replay a drive: how-to/replay-a-drive.md
   - Concepts:

--- a/selfdrive/car/card.py
+++ b/selfdrive/car/card.py
@@ -79,6 +79,8 @@ class Car:
     self.params = Params()
 
     self.can_callbacks = can_comm_callbacks(self.can_sock, self.pm.sock['sendcan'])
+    self.raw_actuators_only = bool(os.environ.get("RAW_ACTUATORS_ONLY")) or self.params.get_bool("RawActuatorsOnly")
+    self._raw_actuators_only_logged = False
 
     is_release = self.params.get_bool("IsReleaseBranch")
 
@@ -239,7 +241,12 @@ class Car:
       # send car controls over can
       now_nanos = self.can_log_mono_time if REPLAY else int(time.monotonic() * 1e9)
       self.last_actuators_output, can_sends = self.CI.apply(CC, now_nanos)
-      self.pm.send('sendcan', can_list_to_can_capnp(can_sends, msgtype='sendcan', valid=CS.canValid))
+      if self.raw_actuators_only:
+        if not self._raw_actuators_only_logged:
+          cloudlog.warning("RAW_ACTUATORS_ONLY enabled: skipping CAN sends and publishing carOutput only.")
+          self._raw_actuators_only_logged = True
+      else:
+        self.pm.send('sendcan', can_list_to_can_capnp(can_sends, msgtype='sendcan', valid=CS.canValid))
 
       self.CC_prev = CC
 


### PR DESCRIPTION
### Motivation

- Provide a way to run controllers while only publishing raw actuator values and without transmitting CAN messages to the vehicle for offline analysis, simulation, or safe validation.
- Allow enabling this behavior via an environment variable or persistent param so it can be toggled in different run contexts.
- Keep existing control and state logic intact while preventing any bus activity when requested.

### Description

- Add a `raw_actuators_only` flag in `selfdrive/car/card.py` that reads `RAW_ACTUATORS_ONLY` or the `RawActuatorsOnly` param and a `_raw_actuators_only_logged` flag to log the mode once.
- When enabled, `card` skips publishing to the `sendcan` socket but continues to populate and publish `carOutput.actuatorsOutput` as before.
- Add `docs/how-to/raw-actuator-output.md` documenting how to enable the mode and how to observe `carOutput` values.
- Update `mkdocs.yml` to include the new how-to document in the site navigation.

### Testing

- No automated tests were run for this change.
- The patch was applied and committed in the working tree without runtime test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bf68f0c083239ec13f4150e680cb)